### PR TITLE
드래그 앤 드롭으로 파일 정보 추출하는 로직 개선

### DIFF
--- a/src/getProcessedFilesInDragAndDrop/index.ts
+++ b/src/getProcessedFilesInDragAndDrop/index.ts
@@ -11,12 +11,6 @@ export const getProcessedFilesInDragAndDrop = async (
   return new Promise((resolve) => {
     const files: ProcessedFile[] = [];
 
-    const getFileInSubDirectory = (
-      entry: FileSystemFileEntry
-    ): Promise<File> => {
-      return new Promise((resolve) => entry.file(resolve));
-    };
-
     /** 비동기로 폴더 내부를 재귀 + 순회하면서 모든 파일들을 추출 */
     const readEntriesAsync = (
       reader: FileSystemDirectoryReader
@@ -25,10 +19,9 @@ export const getProcessedFilesInDragAndDrop = async (
         reader.readEntries(async (entries) => {
           for await (const entry of entries) {
             if (entry.isFile) {
-              const file = await getFileInSubDirectory(
-                entry as FileSystemFileEntry
+              (entry as FileSystemFileEntry).file((file) =>
+                files.push({ file, relativePath: entry.fullPath.slice(1) })
               );
-              files.push({ file, relativePath: entry.fullPath.slice(1) });
               continue;
             }
 

--- a/src/getProcessedFilesInDragAndDrop/index.ts
+++ b/src/getProcessedFilesInDragAndDrop/index.ts
@@ -5,45 +5,69 @@ import { ProcessedFile } from "@/types";
  * @param items drop event 발생시 event.dataTransfer.items를 그대로 넘김
  * @returns 가공된 파일 리스트
  */
-export const getProcessedFilesInDragAndDrop = (
+export const getProcessedFilesInDragAndDrop = async (
   items: DataTransferItemList
-): ProcessedFile[] => {
+): Promise<ProcessedFile[]> => {
   const files: ProcessedFile[] = [];
 
-  /** 폴더 내부에 재귀로 돌면서 파일 추출 */
-  const getEntries = (entryInfo: FileSystemDirectoryEntry) => {
-    entryInfo.createReader().readEntries((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isFile) {
-          (entry as FileSystemFileEntry).file((file) =>
-            files.push({ file, relativePath: entry.fullPath.slice(1) })
-          );
-          return;
-        }
+  const getFileInSubDirectory = (entry: FileSystemFileEntry): Promise<File> => {
+    return new Promise((resolve) => entry.file(resolve));
+  };
 
-        getEntries(entry as FileSystemDirectoryEntry);
+  /** 비동기로 폴더 내부를 재귀 + 순회하면서 모든 파일들을 추출 */
+  const readEntriesAsync = (
+    reader: FileSystemDirectoryReader
+  ): Promise<FileSystemEntry[]> => {
+    return new Promise((resolve) => {
+      reader.readEntries(async (entries) => {
+        for await (const entry of entries) {
+          if (entry.isFile) {
+            const file = await getFileInSubDirectory(
+              entry as FileSystemFileEntry
+            );
+            files.push({ file, relativePath: entry.fullPath.slice(1) });
+            continue;
+          }
+
+          await getEntries(entry as FileSystemDirectoryEntry);
+        }
+        resolve(entries);
       });
     });
   };
 
-  Array.from(items).forEach((item) => {
-    const entryInfo = item.webkitGetAsEntry();
+  /** 폴더 내부에 있는 모든 파일 or 폴더 정보 추출 */
+  const getEntries = async (directoryEntry: FileSystemDirectoryEntry) => {
+    const reader = directoryEntry.createReader();
+
+    const readEntries = async () => {
+      const entries = await readEntriesAsync(reader);
+      if (entries.length > 0) {
+        await readEntries();
+      }
+    };
+
+    await readEntries();
+  };
+
+  for await (const item of Array.from(items)) {
+    const entry = item.webkitGetAsEntry();
 
     // prechecker - 아무것도 없는 경우 null 예외 처리
-    if (!entryInfo) {
+    if (!entry) {
       files.push({ file: null, relativePath: "" });
-      return;
+      continue;
     }
 
     // 파일인 경우
-    if (entryInfo.isFile) {
-      files.push({ file: item.getAsFile(), relativePath: entryInfo.name });
-      return;
+    if (entry.isFile) {
+      files.push({ file: item.getAsFile(), relativePath: entry.name });
+      continue;
     }
 
     // 폴더인 경우
-    getEntries(entryInfo as FileSystemDirectoryEntry);
-  });
+    await getEntries(entry as FileSystemDirectoryEntry);
+  }
 
   return files;
 };


### PR DESCRIPTION
### Task List
- [x] 폴더 내에 파일이 100개 이상 있는 경우 재귀 호출로 모든 파일 가져오도록 개선
- [x] 파일 + 폴더가 섞여있는 채로 드래그 앤 드롭하여 파일 정보 불러올 때 간헐적으로 못 불러오는 현상 수정
<br>

### Related Issue
- https://github.com/wally-wally/file-upload-preprocessor/issues/2
<br>

### Memo
- `getProcessedFilesInDragAndDrop` 함수를 사용하는 곳에서는 아래와 같이 비동기 처리를 해야함
```javascript
async function getFiles(event) {
  return await getProcessedFilesInDragAndDrop(event.dataTransfer.items);
}
```