### PR TITLE
chore: 빌드시 d.ts 파일 포함되도록 수정

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-# :bento: fill-upload-preprocessor Pull Request
+# :file_folder: fill-upload-preprocessor Pull Request
 
 ## Task List
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+# :bento: fill-upload-preprocessor Pull Request
+
+## Task List
+
+<!-- 개조식으로 어떤 작업을 수행했는지 작성 -->
+<br>
+
+## Remarks
+
+<!-- 이번 MR과 관련된 내용들을 자유롭게 작성 -->
+<br>
+
+## Related Issue
+
+<!-- 이번 MR과 관련있는 github issue가 있는 경우 링크 연결 -->

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest --watchAll --verbose --coverage",
     "test:ci": "jest",
-    "build": "webpack --mode production"
+    "build": "webpack --mode production && tsc"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,19 +6,18 @@
     "jsx": "preserve",
     "importHelpers": true,
     "moduleResolution": "node",
-    "experimentalDecorators": true,
-    "allowJs": true,
-    "noEmit": true,
+    "skipLibCheck": true,
     "esModuleInterop": true,
-    "outDir": "",
     "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": false,
-    "sourceMap": true,
+    "emitDeclarationOnly":true,
+    "sourceMap": false,
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
     },
-    "lib": ["esnext", "es5", "dom", "dom.iterable", "es2015"]
+    "lib": ["esnext", "es5", "dom", "dom.iterable", "es2015"],
+    "declaration": true,
+    "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["node_modules", "dist"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ const buildPoint = path.join(__dirname, "dist");
 const aliasPoint = path.join(__dirname, "src");
 
 module.exports = {
-  name: "eat-today",
+  name: "file-upload-preprocessor",
   mode,
   entry: entryPoint,
   module: {


### PR DESCRIPTION
### Task List
- 빌드 명령어에 `tsc`도 포함하도록 수정
- `tsconfig.json`에 `emitDeclarationOnly`, `declaration` 옵션도 활성화되도록 수정
- 빌드 시 타입 정보까지 올바르게 추출된 모습
![image](https://user-images.githubusercontent.com/52685250/175806712-f7aead06-1c24-425d-88fe-4c8ce8b6c559.png)
<br>

### Related Issue
- https://github.com/wally-wally/file-upload-preprocessor/issues/4